### PR TITLE
Add tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _book/
 node_modules/
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ sudo: false
 language: node_js
 install:
   - npm install gitbook-cli -g
+  - pip install --user beautifulsoup4
   - pip install --user ghp-import
 node_js: '4.1'
 script:
   - make _book 
+  - make test
 after_success:
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && make publish-travis > /dev/null 2>&1 || true'
 env:

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,13 @@ _book: node_modules
 node_modules:
 	gitbook install
 
+test: _book
+	python -m unittest tests
+
 clean:
 	@rm -rf _book
 	@rm -rf node_modules
+	@rm -f tests/*.pyc
 
 publish-travis: _book
 	@ghp-import -n ./_book && git push -fq https://${GH_TOKEN}@github.com/$(TRAVIS_REPO_SLUG).git gh-pages > /dev/null

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_references import TestLinksInHtmlFiles

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,13 @@
+def find_files(base, pattern):
+    """
+    """
+    from re import compile
+    from os import walk
+    pat = compile(pattern)
+    return [(root, fname) for root, _, files in walk(base)
+                          for fname in files if pat.match(fname)]
+
+def find_html_files(base):
+    """
+    """
+    return find_files(base, r'.*\.html')

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import unittest
+
+class TestLinksInHtmlFiles(unittest.TestCase):
+    def test_files(self):
+        from .common import find_html_files
+        cond = all(self.check_links_in_file(r, f)
+                   for r, f in find_html_files('_book'))
+        self.assertTrue(cond)
+
+    @classmethod
+    def check_links_in_file(cls, root, fname):
+        from bs4 import BeautifulSoup
+        from os import path
+
+        soup = BeautifulSoup(open(path.join(root, fname)))
+        links = [a.get('href') for a in soup.findAll('a')]
+        links = [l for l in links if l.startswith('.')]  # Only local links
+
+        return all(path.exists(path.join(root, lhref)) for lhref in links)


### PR DESCRIPTION
Travis will now automatically perform tests before publishing the book.
At this point the only check that is performed is whether all relative
links point to existing pages. This can easily be extended by adding
more classes that get picked up by `unittest`.
