### PR TITLE
added handy k5reauth bash function to persistent-screen lesson

### DIFF
--- a/shell/persistent-screen.md
+++ b/shell/persistent-screen.md
@@ -30,4 +30,23 @@ which will create a `tmux` session whose kerberos token is refreshed automatical
 ```bash
 tmux attach-session -t NAME
 ```
-is sufficient.
+or
+```bash
+tmux a
+```
+(if you want to attach the most recently used session) is sufficient.
+
+You will almost certainly want to use an alias or function to access this command. One way to do that would be to copy and paste the following into your `~/.bashrc` (if you use bash):
+```bash
+ktmux(){
+    if [[ -z "$1" ]]; then #if no argument passed
+        k5reauth -f -i 3600 -p USERNAME -k /path/to/USERNAME.keytab -- tmux new-session
+    else #pass the argument as the tmux session name
+        k5reauth -f -i 3600 -p USERNAME -k /path/to/USERNAME.keytab -- tmux new-session -s $1
+    fi
+}
+```
+You could then start a tmux session named “Test” using
+```bash
+ktmux Test
+```

--- a/shell/persistent-screen.md
+++ b/shell/persistent-screen.md
@@ -30,4 +30,23 @@ which will create a `tmux` session whose kerberos token is refreshed automatical
 ```bash
 tmux attach-session -t NAME
 ```
-is sufficient.
+or
+```bash
+tmux a
+```
+(if you want to attach the most recently used session) is sufficient.
+
+You will almost certainly want to use an alias or function to access this command. One way to do that would be to copy and paste the following into your `~/.bashrc` (if you use bash):
+```bash
+ktmux(){
+    if [[ -z "$1" ]]; then #if no argument passed
+        k5reauth -f -i 3600 -p mwilkins -k mwilkins.keytab -- tmux new-session
+    else #pass the argument as the tmux session name
+        k5reauth -f -i 3600 -p mwilkins -k mwilkins.keytab -- tmux new-session -s $1
+    fi
+}
+```
+You could then start a tmux session named “Test” using
+```bash
+ktmux Test
+```


### PR DESCRIPTION
minor edit, but useful for student reference, I think.

By the way, thanks for including this. I didn't know I could do this and the last time I asked about it a couple years ago the instructions here didn't even work.